### PR TITLE
Update passport-core.clar

### DIFF
--- a/contracts/passport-core.clar
+++ b/contracts/passport-core.clar
@@ -15,8 +15,17 @@
     ;; Check permissions
     (asserts! (contract-call? .access-control can-issue-badges-in-community community-id tx-sender) err-unauthorized)
     
-    ;; Mint badge through issuer
-    (contract-call? .badge-issuer mint-badge recipient template-id)
+    (let ((mint-result (contract-call? .badge-issuer mint-badge recipient template-id)))
+      (begin
+        (print {
+          event: "badge-created",
+          user: recipient,
+          template: template-id,
+          community: community-id
+        })
+        mint-result
+      )
+    )
   )
 )
 


### PR DESCRIPTION
Add badge-created event emission to create-passport-badge

- Emits a standardized event after a badge is successfully minted
- Includes recipient, template ID, and community ID
- Ensures event only prints after permission check and successful mint